### PR TITLE
Add sqlalchemy to the licences

### DIFF
--- a/EXTERNAL_LIBRARIES_LICENSES.md
+++ b/EXTERNAL_LIBRARIES_LICENSES.md
@@ -23,3 +23,4 @@
 * `animate`: MIT License
 * `flag-icon`: MIT License
 * `jit`: https://github.com/philogb/jit/blob/master/LICENSE
+* `sqlalchemy`: MIT License


### PR DESCRIPTION
#### Checklist
- [x] I have followed the [Contributor Guidelines](https://github.com/zdresearch/OWASP-Nettacker/wiki/Developers#contribution-guidelines).
- [x] I have added the relevant documentation.
- [x] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request
Added sqlalchemy MIT license to external licenses.
#### Your development environment
- OS: `Ubuntu`
- OS Version: `16.04`
- Python Version: `2.7`