### PR TITLE
Add license for intro.js

### DIFF
--- a/EXTERNAL_LIBRARIES_LICENSES.md
+++ b/EXTERNAL_LIBRARIES_LICENSES.md
@@ -25,3 +25,4 @@
 * `jit`: https://github.com/philogb/jit/blob/master/LICENSE
 * `sqlalchemy`: MIT License
 * `canari`: GNU General Public License v3.0
+* `intro.js`: GNU AGPLv3


### PR DESCRIPTION
#### Checklist
- [x] I have followed the [Contributor Guidelines](https://github.com/zdresearch/OWASP-Nettacker/wiki/Developers#contribution-guidelines).
- [x] I have added the relevant documentation.
- [x] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request
I forgot to add the license for intro.js in my pull request. This adds the license of the same.

#### Your development environment
- OS: `Ubuntu`
- OS Version: `16.04`
- Python Version: `2.7.12`