### PR TITLE
Removed code duplication

### DIFF
--- a/lib/http_fuzzer/engine.py
+++ b/lib/http_fuzzer/engine.py
@@ -158,50 +158,17 @@ def __http_request_maker(req_type, url, headers, retries, time_sleep, timeout_se
     r = None
     while True:
         try:
-            if timeout_sec is None:
-                if req_type == "POST":
-                    if content_type == 'application/data':
-                        r = requests.post(url=url, headers=headers, data=data, verify=False)
-                    elif content_type == 'application/json':
-                        r = requests.post(url=url, headers=headers, json=data, verify=False)
-                elif req_type == "PUT":
-                    if content_type == 'application/data':
-                        r = requests.put(url=url, headers=headers, data=data, verify=False)
-                    elif content_type == 'application/json':
-                        r = requests.put(url=url, headers=headers, json=json, verify=False)
-                elif req_type == "PATCH":
-                    if content_type == 'application/data':
-                        r = requests.patch(url=url, headers=headers, data=data, verify=False)
-                    elif content_type == 'application/json':
-                        r = requests.patch(url=url, headers=headers, json=data, verify=False)
-                elif req_type == "GET":
-                    r = requests.get(url=url, headers=headers, verify=False)
-                elif req_type == "HEAD":
-                    r = requests.head(url=url, headers=headers, verify=False)
-                elif req_type == "DELETE":
-                    r = requests.delete(url=url, headers=headers, verify=False)
-            else:
-                if req_type == "POST":
-                    if content_type == 'application/data':
-                        r = requests.post(url=url, headers=headers, data=data, timeout=timeout_sec, verify=False)
-                    elif content_type == 'application/json':
-                        r = requests.post(url=url, headers=headers, json=data, timeout=timeout_sec, verify=False)
-                elif req_type == "PUT":
-                    if content_type == 'application/data':
-                        r = requests.put(url=url, headers=headers, data=data, timeout=timeout_sec, verify=False)
-                    elif content_type == 'application/json':
-                        r = requests.put(url=url, headers=headers, json=data, timeout=timeout_sec, verify=False)
-                elif req_type == "PATCH":
-                    if content_type == 'application/data':
-                        r = requests.patch(url=url, headers=headers, data=data, timeout=timeout_sec, verify=False)
-                    elif content_type == 'application/json':
-                        r = requests.patch(url=url, headers=headers, json=data, timeout=timeout_sec, verify=False)
-                elif req_type == "GET":
-                    r = requests.get(url=url, headers=headers, timeout=timeout_sec, verify=False)
-                elif req_type == "HEAD":
-                    r = requests.head(url=url, headers=headers, timeout=timeout_sec, verify=False)
-                elif req_type == "DELETE":
-                    r = requests.delete(url=url, headers=headers, timeout=timeout_sec, verify=False)
+            req_type = req_type.lower()
+            if req_type in ['post', 'put', 'patch']:
+                if content_type == 'application/data':
+                    r = eval('requests.{}(url=url, headers=headers, data=data,\
+                             timeout=timeout_sec, verify=False)'.format(req_type))
+                elif content_type == 'application/json':
+                    r = eval('requests.{}(url=url, headers=headers, json=data,\
+                             timeout=timeout_sec, verify=False)'.format(req_type))
+            elif req_type in ['get', 'head', 'delete']:
+                r = eval('requests.{}(url=url, headers=headers,\
+                         verify=False, timeout=timeout_sec)'.format(req_type))
             break
         except Exception as _:
             exits += 1


### PR DESCRIPTION
#### Checklist
- [x] I have followed the [Contributor Guidelines](https://github.com/zdresearch/OWASP-Nettacker/wiki/Developers#contribution-guidelines).
- [x] I have added the relevant documentation.
- [x] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request
Issue : #135 

There were a few code duplication in `lib/http_fuzzer/engine.py`, thus violating the DRY principle. This PR deals with those issues.
`timeout_sec` is by default set to `None`. We need not need to create a separate `if-else` regarding this. We can pass `timeout=timeout_sec` provided `timeout=None` is a valid parameter.

We can generate the request statement dynamically by using `eval` function, this will reduce chances of repeating ourselves.

#### Your development environment
- OS: `Kali Linux`
- OS Version: `2`
- Python Version: `3.6.6`