### PR TITLE
Fix typo in host json report

### DIFF
--- a/database/db.py
+++ b/database/db.py
@@ -378,7 +378,7 @@ def __logs_to_report_json(host, language):
             data = {
                 "SCAN_ID": log.scan_id,
                 "HOST": host,
-                "USERNAME": log.usernamr,
+                "USERNAME": log.username,
                 "PASSWORD": log.password,
                 "PORT": log.port,
                 "TYPE": log.type,


### PR DESCRIPTION
#### Checklist
- [X] I have followed the [Contributor Guidelines](https://github.com/zdresearch/OWASP-Nettacker/wiki/Developers#contribution-guidelines).
- [_] I have added the relevant documentation.
- [X] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request
Fix a typo in host json report resulting in an always empty list returned.

#### Your development environment
- OS: `Ubuntu`
- OS Version: `16.04`
- Python Version: `3.6.7`