### PR TITLE
Added some latest user agents to the list & fixed a typo

### DIFF
--- a/lib/http_fuzzer/engine.py
+++ b/lib/http_fuzzer/engine.py
@@ -28,7 +28,7 @@ def user_agents_list():
         "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.5) Gecko/20060719 Firefox/1.5.0.5",
         "Googlebot/2.1 ( http://www.googlebot.com/bot.html)",
         "Mozilla/5.0 (X11; U; Linux x86_64; en-US) AppleWebKit/534.13 (KHTML, like Gecko) Ubuntu/10.04"
-        " Chromium/9.0.595.0 Chrome/9.0.595.0 Safari/534.13",
+        "Chromium/9.0.595.0 Chrome/9.0.595.0 Safari/534.13",
         "Mozilla/5.0 (compatible; MSIE 7.0; Windows NT 5.2; WOW64; .NET CLR 2.0.50727)",
         "Opera/9.80 (Windows NT 5.2; U; ru) Presto/2.5.22 Version/10.51",
         "Mozilla/5.0 (compatible; 008/0.83; http://www.80legs.com/webcrawler.html) Gecko/2008032620",
@@ -41,6 +41,16 @@ def user_agents_list():
         "Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)",
         "Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)",
         "msnbot/1.1 (+http://search.msn.com/msnbot.htm)"
+        #Windows 10-based PC using Edge browser
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246"
+        #Chrome OS-based laptop using Chrome browser (Chromebook)
+        "Mozilla/5.0 (X11; CrOS x86_64 8172.45.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.64 Safari/537.36"
+        #Mac OS X-based computer using a Safari browser
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9"
+        #Windows 7-based PC using a Chrome browser
+        "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36"
+        #Linux-based PC using a Firefox browser
+        "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1"
     ]
 
 

--- a/lib/http_fuzzer/engine.py
+++ b/lib/http_fuzzer/engine.py
@@ -27,7 +27,7 @@ def user_agents_list():
     return [
         "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.5) Gecko/20060719 Firefox/1.5.0.5",
         "Googlebot/2.1 ( http://www.googlebot.com/bot.html)",
-        "Mozilla/5.0 (X11; U; Linux x86_64; en-US) AppleWebKit/534.13 (KHTML, like Gecko) Ubuntu/10.04"
+        "Mozilla/5.0 (X11; U; Linux x86_64; en-US) AppleWebKit/534.13 (KHTML, like Gecko) Ubuntu/10.04",
         "Chromium/9.0.595.0 Chrome/9.0.595.0 Safari/534.13",
         "Mozilla/5.0 (compatible; MSIE 7.0; Windows NT 5.2; WOW64; .NET CLR 2.0.50727)",
         "Opera/9.80 (Windows NT 5.2; U; ru) Presto/2.5.22 Version/10.51",
@@ -36,21 +36,21 @@ def user_agents_list():
         "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
         "Googlebot/2.1 (+http://www.googlebot.com/bot.html)",
         "Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)",
-        "YahooSeeker/1.2 (compatible; Mozilla 4.0; MSIE 5.5; yahooseeker at yahoo-inc dot com ; "
+        "YahooSeeker/1.2 (compatible; Mozilla 4.0; MSIE 5.5; yahooseeker at yahoo-inc dot com ; ",
         "http://help.yahoo.com/help/us/shop/merchant/)",
         "Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)",
         "Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)",
-        "msnbot/1.1 (+http://search.msn.com/msnbot.htm)"
+        "msnbot/1.1 (+http://search.msn.com/msnbot.htm)",
         #Windows 10-based PC using Edge browser
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246"
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246",
         #Chrome OS-based laptop using Chrome browser (Chromebook)
-        "Mozilla/5.0 (X11; CrOS x86_64 8172.45.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.64 Safari/537.36"
+        "Mozilla/5.0 (X11; CrOS x86_64 8172.45.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.64 Safari/537.36",
         #Mac OS X-based computer using a Safari browser
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9"
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9",
         #Windows 7-based PC using a Chrome browser
-        "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36"
+        "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36",
         #Linux-based PC using a Firefox browser
-        "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1"
+        "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1",
     ]
 
 


### PR DESCRIPTION
Added the following user agents: Windows 10-based PC using Edge browser, Chrome OS-based laptop using Chrome browser (Chromebook), Mac OS X-based computer using a Safari browser, Windows 7-based PC using a Chrome browser, Linux-based PC using a Firefox browser

#### Checklist
- [X] I have followed the [Contributor Guidelines](https://github.com/zdresearch/OWASP-Nettacker/wiki/Developers#contribution-guidelines).
- [X] I have added the relevant documentation.
- [X] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request

#### Your development environment
- OS: `Linux`
- OS Version: `Ubuntu`
- Python Version: `3.x`