### PR TITLE
Changed XML-RPC brute to make tool fast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 
 #ignore IDE settings
 *.idea*
-
+#ignore vscode files
+.vscode
 #setup
 build/*
 dist/*

--- a/lib/brute/wp_xmlrpc/engine.py
+++ b/lib/brute/wp_xmlrpc/engine.py
@@ -63,10 +63,11 @@ def check(target, port, headers, timeout_sec, log_in_file, language,
                 r = requests.post(
                         target, timeout = timeout_sec, headers = headers, data = postdata)
                 if "demo.sayhello" in r.text.lower():
-                    info(messages(language, "XML-RPC enabled").format(
-                                    target, port))
+                    info(messages(language, "target_vulnerable").format(
+                                    target, port, "XMLRPC DOS attacks"))
+                    __log_into_file(thread_tmp_filename, 'w', '0', language)
                     data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': port, 'TYPE': 'wp_xmlrpc_brute',
-                               'DESCRIPTION': messages(language, "XML-RPC enabled") , 'TIME': now(), 'CATEGORY': "brute", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd}) + "\n"
+                               'DESCRIPTION': messages(language, "vulnerable").format("XML-RPC DOS attacks!!") , 'TIME': now(), 'CATEGORY': "brute", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd}) + "\n"
                     __log_into_file(log_in_file, 'a', data, language)
             except:
                 n += 1
@@ -209,11 +210,13 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
             except KeyboardInterrupt:
                 break
         thread_write = int(open(thread_tmp_filename).read().rsplit()[0])
-        info(messages(language, "XML-RPC enabled").format(
-            'XML-RPC'))
-        data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': port, 'TYPE': 'wp_xmlrpc_brute',
-                        'DESCRIPTION': messages(language, "XML-RPC enabled"), 'TIME': now(), 'CATEGORY': "brute", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd}) + "\n"
-        __log_into_file(log_in_file, 'a', data, language)
+        if thread_write is 1 and verbose_level is not 0:
+
+            info(messages(language, "no_vulnerability_found").format(
+                'XML-RPC'))
+            data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': port, 'TYPE': 'wp_xmlrpc_brute',
+                            'DESCRIPTION': messages(language, "no_vulnerability_found").format("XML-RPC DOS attacks"), 'TIME': now(), 'CATEGORY': "brute", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd}) + "\n"
+            __log_into_file(log_in_file, 'a', data, language)
         os.remove(thread_tmp_filename)
     else:
         warn(messages(language, "input_target_error").format(

--- a/lib/language/messages_en.py
+++ b/lib/language/messages_en.py
@@ -29,6 +29,7 @@ def all_messages():
             "read_target": "read target(s) from file",
             "scan_method_options": "Scan method options",
             "choose_scan_method": "choose scan method {0}",
+            "XML-RPC enabled": "XML-RPC enabled",
             "exclude_scan_method": "choose scan method to exclude {0}",
             "username_list": "username(s) list, separate with \",\"",
             "username_from_file": "read username(s) from file",


### PR DESCRIPTION
The current wp_xmlrpc_brute module was doing the direct brute force on the web application with very weak wordlist files. So To be honest, without doing the brute force what we can do make tool faster is just check that xmlrpc is enable or not. This can be achieved using two techniques:
1. Seeing the response to the request  : http://domain/xmlrpc.php and the response should contain the string: "XML-RPC server accepts POST requests only."
2. But the second is more accurate: Making an actual post request and see the response which tells which requests we can make using xml.
So what I did is I just changed the code to make sure that it gives the faster response by just telling the web is vulnerable to xmlrpc or not. This will help pentester in many aspects:
1. He has to input this command to test for xmlrpc:
`python3 nettacker.py -m wp_xmlrpc_brute -i domain.com
`
2. After our tool confirms that the web is vulnerable, he can immideately go to burp suite and start intruder for brute forcing with **better username, password list.** This will save his time.
I just tried and it took much time so I decieded to do this.
The results are:
![image](https://user-images.githubusercontent.com/32503192/81502239-6d36ab00-92fa-11ea-892c-1fcc414992aa.png)

@Ali-Razmjoo please review it. I think it should help tool to get fast.
#### Checklist
- [X] I have followed the [Contributor Guidelines](https://github.com/zdresearch/OWASP-Nettacker/wiki/Developers#contribution-guidelines).
- [X] I have added the relevant documentation.
- [X] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request

#### Your development environment
- OS: `Linux`
- OS Version: `Ubuntu`
- Python Version: `3.6.9`